### PR TITLE
Add Python x402 action provider

### DIFF
--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/__init__.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/__init__.py
@@ -27,6 +27,7 @@ from .twitter.twitter_action_provider import TwitterActionProvider, twitter_acti
 from .wallet.wallet_action_provider import WalletActionProvider, wallet_action_provider
 from .weth.weth_action_provider import WethActionProvider, weth_action_provider
 from .wow.wow_action_provider import WowActionProvider, wow_action_provider
+from .x402.x402_action_provider import X402ActionProvider, x402_action_provider
 
 __all__ = [
     "Action",
@@ -64,4 +65,6 @@ __all__ = [
     "weth_action_provider",
     "WowActionProvider",
     "wow_action_provider",
+    "X402ActionProvider",
+    "x402_action_provider",
 ]

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/x402/README.md
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/x402/README.md
@@ -1,0 +1,70 @@
+# X402 Action Provider
+
+This directory contains the **X402ActionProvider** implementation, which provides actions to interact with **x402-protected APIs** that require payment to access.
+
+## Directory Structure
+
+```
+x402/
+├── x402_action_provider.py  # Main provider with x402 payment functionality
+├── schemas.py               # x402 action schemas
+├── __init__.py              # Main exports
+└── README.md                # This file
+```
+
+## Actions
+
+- `paid_request`: Make HTTP requests to x402-protected API endpoints with automatic payment handling
+- `fetch_payment_info`: Get payment information from x402-protected endpoints without making payments
+
+## Overview
+
+The x402 protocol enables APIs to require micropayments for access. When a client makes a request to a protected endpoint, the server responds with a `402 Payment Required` status code along with payment instructions. This action provider automatically handles the entire payment flow:
+
+1. Makes the initial request to the protected API
+2. If a 402 response is received, automatically processes the payment using the wallet
+3. Retries the request with payment proof
+4. Returns the API response data
+
+## Usage
+
+### `paid_request` Action
+
+The `paid_request` action accepts the following parameters:
+
+- **url**: The full URL of the x402-protected API endpoint
+- **method**: HTTP method (GET, POST, PUT, DELETE, PATCH) - defaults to GET
+- **headers**: Optional additional headers to include in the request
+- **body**: Optional request body for POST/PUT/PATCH requests
+
+### `fetch_payment_info` Action
+
+The `fetch_payment_info` action accepts the following parameters:
+
+- **url**: The full URL of the x402-protected API endpoint
+- **method**: HTTP method (GET, POST, PUT, DELETE, PATCH) - defaults to GET
+- **headers**: Optional additional headers to include in the request
+
+This action is useful for:
+- Checking payment requirements before committing to a paid request
+- Understanding the cost structure of an API
+- Getting details about accepted payment tokens and amounts
+- Debugging x402 payment configurations
+
+## Network Support
+
+The x402 provider currently supports the following networks:
+- `base-mainnet`
+- `base-sepolia`
+
+The provider requires EVM-compatible networks where the wallet can sign payment transactions.
+
+## Dependencies
+
+This action provider requires:
+- `requests` - For making HTTP requests
+- `x402-requests` - For handling x402 payment flows
+
+## Notes
+
+For more information on the **x402 protocol**, visit the [x402 documentation](https://x402.gitbook.io/x402/).

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/x402/__init__.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/x402/__init__.py
@@ -1,0 +1,1 @@
+"""X402 action provider for paid API requests."""

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/x402/schemas.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/x402/schemas.py
@@ -1,0 +1,32 @@
+"""Schemas for the X402 action provider."""
+
+from typing import Any, Literal
+from pydantic import BaseModel, Field, HttpUrl
+
+
+class PaidRequestSchema(BaseModel):
+    """Input schema for making a paid request to an x402-protected endpoint."""
+
+    url: HttpUrl = Field(..., description="The URL of the x402-protected API endpoint")
+    method: Literal["GET", "POST", "PUT", "DELETE", "PATCH"] = Field(
+        "GET", description="The HTTP method to use for the request"
+    )
+    headers: dict[str, str] | None = Field(
+        default=None, description="Optional headers to include in the request"
+    )
+    body: Any | None = Field(
+        default=None, description="Optional request body for POST/PUT/PATCH requests"
+    )
+
+
+class FetchPaymentInfoSchema(BaseModel):
+    """Input schema for fetching payment info from an x402 endpoint."""
+
+    url: HttpUrl = Field(..., description="The URL of the x402-protected API endpoint")
+    method: Literal["GET", "POST", "PUT", "DELETE", "PATCH"] = Field(
+        "GET", description="The HTTP method to use for the request"
+    )
+    headers: dict[str, str] | None = Field(
+        default=None, description="Optional headers to include in the request"
+    )
+

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/x402/x402_action_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/x402/x402_action_provider.py
@@ -1,0 +1,219 @@
+"""Action provider for making requests to x402-protected APIs."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import requests
+
+from ..action_decorator import create_action
+from ..action_provider import ActionProvider
+from ...network import Network
+from ...wallet_providers import EvmWalletProvider
+from .schemas import FetchPaymentInfoSchema, PaidRequestSchema
+
+try:
+    # Optional dependency used to handle the payment flow automatically.
+    from x402_requests import with_payment_interceptor, decode_x_payment_response
+except Exception:  # pragma: no cover - fallback when library is not installed
+    def with_payment_interceptor(session: requests.Session, account: Any) -> requests.Session:  # type: ignore[return-type]
+        raise NotImplementedError("x402-requests library is required")
+
+    def decode_x_payment_response(data: str) -> Any:  # type: ignore[return-type]
+        raise NotImplementedError("x402-requests library is required")
+
+
+SUPPORTED_NETWORKS = ["base-mainnet", "base-sepolia"]
+
+
+class X402ActionProvider(ActionProvider[EvmWalletProvider]):
+    """Action provider for x402-protected API requests."""
+
+    def __init__(self) -> None:
+        super().__init__("x402", [])
+
+    @create_action(
+        name="paid_request",
+        description=(
+            """\
+This tool makes HTTP requests to APIs that are protected by x402 paywalls. It automatically handles the payment flow when a 402 Payment Required response is received.
+
+Inputs:
+- url: The full URL of the x402-protected API endpoint
+- method: The HTTP method (GET, POST, PUT, DELETE, PATCH) - defaults to GET
+- headers: Optional additional headers to include in the request
+- body: Optional request body for POST/PUT/PATCH requests
+
+The tool will:
+1. Make the initial request to the protected endpoint
+2. If a 402 Payment Required response is received, automatically handle the payment using the wallet
+3. Retry the request with payment proof
+4. Return the API response data
+
+Supported on EVM networks where the wallet can sign payment transactions.
+"""
+        ),
+        schema=PaidRequestSchema,
+    )
+    def paid_request(self, wallet_provider: EvmWalletProvider, args: dict[str, Any]) -> str:
+        """Make a paid request to an x402-protected endpoint."""
+        try:
+            validated = PaidRequestSchema(**args)
+
+            account = wallet_provider.to_signer()
+            session = with_payment_interceptor(requests.Session(), account)
+
+            response = session.request(
+                url=str(validated.url),
+                method=validated.method,
+                headers=validated.headers,
+                json=validated.body,
+            )
+
+            payment_header = response.headers.get("x-payment-response")
+            payment_response: Any | None = None
+            if payment_header:
+                try:
+                    payment_response = decode_x_payment_response(payment_header)
+                except Exception:
+                    try:
+                        payment_response = json.loads(payment_header)
+                    except Exception:
+                        payment_response = {
+                            "error": "Failed to decode payment response",
+                            "rawHeader": payment_header,
+                        }
+
+            result = {
+                "success": True,
+                "url": str(validated.url),
+                "method": validated.method,
+                "status": response.status_code,
+                "data": response.json() if isinstance(response.text, str) else response.text,
+                "paymentResponse": payment_response,
+            }
+            return json.dumps(result, indent=2)
+        except requests.RequestException as exc:
+            if exc.response is not None:
+                data = None
+                try:
+                    data = exc.response.json()
+                except Exception:
+                    pass
+                message = data.get("error") if isinstance(data, dict) else exc.response.reason
+                return f"Error making paid request to {args.get('url')}: HTTP {exc.response.status_code} - {message}"
+            if exc.request is not None:
+                return f"Error making paid request to {args.get('url')}: Network error - {exc}"  # type: ignore[str-format]
+            return f"Error making paid request to {args.get('url')}: {exc}"
+        except Exception as exc:  # pragma: no cover - generic fallback
+            return f"Error making paid request to {args.get('url')}: {exc}"
+
+    @create_action(
+        name="fetch_payment_info",
+        description=(
+            """\
+This tool fetches payment information from x402-protected API endpoints without actually making any payments. It's useful for checking payment requirements before deciding whether to proceed with a paid request.
+
+Inputs:
+- url: The full URL of the x402-protected API endpoint
+- method: The HTTP method (GET, POST, PUT, DELETE, PATCH) - defaults to GET
+- headers: Optional additional headers to include in the request
+
+The tool will:
+1. Make a request to the protected endpoint
+2. Receive the 402 Payment Required response with payment details
+3. Return information about the payment requirements (amount, token, etc.)
+
+Note: Payment amounts are returned in the smallest unit of the token. For example, for USDC (which has 6 decimal places) maxAmountRequired "10000" corresponds to 0.01 USDC.
+
+This is useful for understanding what payment will be required before using the paid_request action.
+"""
+        ),
+        schema=FetchPaymentInfoSchema,
+    )
+    def fetch_payment_info(self, wallet_provider: EvmWalletProvider, args: dict[str, Any]) -> str:
+        """Fetch payment info from an x402-protected endpoint."""
+        try:
+            validated = FetchPaymentInfoSchema(**args)
+            response = requests.request(
+                url=str(validated.url),
+                method=validated.method,
+                headers=validated.headers,
+            )
+            if response.status_code == 402:
+                payment_header = response.headers.get("x-payment-response")
+                payment_details: Any | None = None
+                if payment_header:
+                    try:
+                        payment_details = decode_x_payment_response(payment_header)
+                    except Exception:
+                        try:
+                            payment_details = json.loads(payment_header)
+                        except Exception:
+                            payment_details = {
+                                "error": "Failed to decode payment response",
+                                "rawHeader": payment_header,
+                            }
+                result = {
+                    "paymentRequired": True,
+                    "url": str(validated.url),
+                    "status": 402,
+                    "data": response.json(),
+                    "paymentDetails": payment_details,
+                }
+                return json.dumps(result, indent=2)
+
+            result = {
+                "paymentRequired": False,
+                "url": str(validated.url),
+                "status": response.status_code,
+                "data": response.json() if isinstance(response.text, str) else response.text,
+            }
+            return json.dumps(result, indent=2)
+        except requests.RequestException as exc:
+            if exc.response is not None:
+                if exc.response.status_code == 402:
+                    payment_header = exc.response.headers.get("x-payment-response")
+                    payment_details: Any | None = None
+                    if payment_header:
+                        try:
+                            payment_details = decode_x_payment_response(payment_header)
+                        except Exception:
+                            try:
+                                payment_details = json.loads(payment_header)
+                            except Exception:
+                                payment_details = {
+                                    "error": "Failed to decode payment response",
+                                    "rawHeader": payment_header,
+                                }
+                    result = {
+                        "paymentRequired": True,
+                        "url": str(args.get("url")),
+                        "status": 402,
+                        "paymentDetails": payment_details,
+                        "data": exc.response.json(),
+                    }
+                    return json.dumps(result, indent=2)
+                data = None
+                try:
+                    data = exc.response.json()
+                except Exception:
+                    pass
+                message = data.get("error") if isinstance(data, dict) else exc.response.reason
+                return f"Error fetching payment info from {args.get('url')}: HTTP {exc.response.status_code} - {message}"
+            if exc.request is not None:
+                return f"Error fetching payment info from {args.get('url')}: Network error - {exc}"  # type: ignore[str-format]
+            return f"Error fetching payment info from {args.get('url')}: {exc}"
+        except Exception as exc:  # pragma: no cover - generic fallback
+            return f"Error fetching payment info from {args.get('url')}: {exc}"
+
+    def supports_network(self, network: Network) -> bool:
+        """Check if the provider supports the given network."""
+        return network.protocol_family == "evm" and network.network_id in SUPPORTED_NETWORKS
+
+
+def x402_action_provider() -> X402ActionProvider:
+    """Factory for X402ActionProvider."""
+    return X402ActionProvider()
+

--- a/python/coinbase-agentkit/tests/action_providers/x402/conftest.py
+++ b/python/coinbase-agentkit/tests/action_providers/x402/conftest.py
@@ -1,0 +1,48 @@
+"""Fixtures for X402 action provider tests."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from coinbase_agentkit.action_providers.x402.x402_action_provider import X402ActionProvider
+from coinbase_agentkit.wallet_providers.evm_wallet_provider import EvmWalletProvider
+from coinbase_agentkit.network import Network
+
+MOCK_SIGNER = "mock-signer"
+MOCK_URL = "https://www.x402.org/protected"
+MOCK_NETWORK = Network(protocol_family="evm", network_id="base-sepolia")
+
+
+@pytest.fixture
+def mock_wallet_provider():
+    wallet = Mock(spec=EvmWalletProvider)
+    wallet.to_signer.return_value = MOCK_SIGNER
+    wallet.get_network.return_value = MOCK_NETWORK
+    return wallet
+
+
+@pytest.fixture
+def mock_request():
+    with patch("requests.request") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_with_payment_interceptor():
+    with patch(
+        "coinbase_agentkit.action_providers.x402.x402_action_provider.with_payment_interceptor"
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_decode_payment_response():
+    with patch(
+        "coinbase_agentkit.action_providers.x402.x402_action_provider.decode_x_payment_response"
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def provider():
+    return X402ActionProvider()

--- a/python/coinbase-agentkit/tests/action_providers/x402/test_action_provider.py
+++ b/python/coinbase-agentkit/tests/action_providers/x402/test_action_provider.py
@@ -1,0 +1,148 @@
+from unittest.mock import Mock
+
+import json
+import requests
+
+import pytest
+
+from coinbase_agentkit.action_providers.x402.x402_action_provider import (
+    X402ActionProvider,
+)
+from coinbase_agentkit.network import Network
+
+
+def test_supports_network(provider):
+    network = Network(protocol_family="evm", network_id="base-mainnet")
+    assert provider.supports_network(network)
+
+    network = Network(protocol_family="evm", network_id="base-sepolia")
+    assert provider.supports_network(network)
+
+    network = Network(protocol_family="evm", network_id="ethereum")
+    assert not provider.supports_network(network)
+
+    network = Network(protocol_family="solana", network_id="mainnet")
+    assert not provider.supports_network(network)
+
+
+def test_fetch_payment_info_402(
+    provider,
+    mock_wallet_provider,
+    mock_request,
+    mock_decode_payment_response,
+):
+    mock_request.return_value.status_code = 402
+    mock_request.return_value.json.return_value = {"detail": "payment"}
+    mock_request.return_value.headers = {"x-payment-response": "encoded"}
+    mock_decode_payment_response.return_value = {"success": True}
+
+    result = provider.fetch_payment_info(
+        mock_wallet_provider,
+        {"url": "https://www.x402.org/protected", "method": "GET"},
+    )
+
+    data = json.loads(result)
+    assert data["paymentRequired"] is True
+    assert data["status"] == 402
+    assert data["paymentDetails"] == {"success": True}
+
+
+def test_fetch_payment_info_non_payment(provider, mock_wallet_provider, mock_request):
+    mock_request.return_value.status_code = 200
+    mock_request.return_value.json.return_value = {"message": "ok"}
+    mock_request.return_value.headers = {}
+
+    result = provider.fetch_payment_info(
+        mock_wallet_provider,
+        {"url": "https://api.example.com/free", "method": "GET"},
+    )
+
+    data = json.loads(result)
+    assert data["paymentRequired"] is False
+    assert data["status"] == 200
+    assert data["data"] == {"message": "ok"}
+
+
+def test_fetch_payment_info_http_error(provider, mock_wallet_provider, mock_request):
+    response = Mock()
+    response.status_code = 500
+    response.json.return_value = {"error": "server"}
+    response.reason = "Internal Server Error"
+    error = requests.RequestException(response=response, request=None)
+    mock_request.side_effect = error
+
+    result = provider.fetch_payment_info(
+        mock_wallet_provider,
+        {"url": "https://api.example.com/endpoint", "method": "GET"},
+    )
+
+    assert "HTTP 500" in result
+    assert "server" in result
+
+
+def test_fetch_payment_info_network_error(provider, mock_wallet_provider, mock_request):
+    error = requests.RequestException("timeout")
+    error.request = Mock()
+    mock_request.side_effect = error
+
+    result = provider.fetch_payment_info(
+        mock_wallet_provider,
+        {"url": "https://api.example.com/endpoint", "method": "GET"},
+    )
+
+    assert "Network error" in result
+
+
+def test_paid_request_success_with_payment(
+    provider,
+    mock_wallet_provider,
+    mock_request,
+    mock_with_payment_interceptor,
+    mock_decode_payment_response,
+):
+    mock_with_payment_interceptor.return_value.request = mock_request
+    mock_request.return_value.status_code = 200
+    mock_request.return_value.json.return_value = {"data": "ok"}
+    mock_request.return_value.headers = {"x-payment-response": "encoded"}
+    mock_decode_payment_response.return_value = {"success": True}
+
+    result = provider.paid_request(
+        mock_wallet_provider,
+        {"url": MOCK_URL, "method": "GET"},
+    )
+    data = json.loads(result)
+    assert data["success"] is True
+    assert data["status"] == 200
+    assert data["paymentResponse"] == {"success": True}
+
+
+def test_paid_request_http_error(provider, mock_wallet_provider, mock_request, mock_with_payment_interceptor):
+    mock_with_payment_interceptor.return_value.request = mock_request
+    response = Mock()
+    response.status_code = 400
+    response.json.return_value = {"error": "bad"}
+    response.reason = "Bad Request"
+    error = requests.RequestException(response=response, request=None)
+    mock_request.side_effect = error
+
+    result = provider.paid_request(
+        mock_wallet_provider,
+        {"url": MOCK_URL, "method": "POST"},
+    )
+
+    assert "HTTP 400" in result
+    assert "bad" in result
+
+
+def test_paid_request_network_error(provider, mock_wallet_provider, mock_request, mock_with_payment_interceptor):
+    mock_with_payment_interceptor.return_value.request = mock_request
+    error = requests.RequestException("timeout")
+    error.request = Mock()
+    mock_request.side_effect = error
+
+    result = provider.paid_request(
+        mock_wallet_provider,
+        {"url": MOCK_URL, "method": "GET"},
+    )
+    assert "Network error" in result
+


### PR DESCRIPTION
## Summary
- implement x402 action provider in Python with paid_request and fetch_payment_info actions
- document provider in README
- expose new provider in package exports
- add unit tests for the new provider

## Testing
- `make format` *(fails: Failed to download `pydantic`)*
- `make lint` *(fails: Failed to download `urllib3`)*
- `make test` *(fails: Failed to download `cryptography`)*

------
https://chatgpt.com/codex/tasks/task_e_68520e4a852c8333ba522d66f963d5fb