### PR TITLE
Add x402-requests Python dependency

### DIFF
--- a/python/coinbase-agentkit/pyproject.toml
+++ b/python/coinbase-agentkit/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "web3>=7.6.0,<8",
     "python-dotenv>=1.0.1,<2",
     "requests>=2.31.0,<3",
+    "x402-requests>=0.3.3,<0.4",
     "allora-sdk>=0.2.0,<0.3",
     "paramiko>=3.5.1,<4",
     "nilql>=0.0.0a12,<0.0.1",


### PR DESCRIPTION
## Summary
- add `x402-requests` library requirement to the Python package

## Testing
- `make format lint test` *(fails: Failed to download `websockets==15.0.1`)*

------
https://chatgpt.com/codex/tasks/task_e_6852b4a06f7083338c0b4f20e88f31aa